### PR TITLE
GH5 Adding showcase functionality

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -99,6 +99,44 @@ specifies a single dataset and the `resource_name` specifies the resource to whi
 The `hdx_hxl_preview_file_path` points to a JSON format file with the key `hxl_preview_config` which
 contains the Quick Chart definition. This file is converted to a single string via a temporary yaml file so should be easily readable. Quick Chart recipe documentation can be found [here](https://github.com/OCHA-DAP/hxl-recipes?tab=readme-ov-file). There is an example file in the `hdx-cli-toolkit` [repo](https://github.com/OCHA-DAP/hdx-cli-toolkit/blob/main/tests/fixtures/quickchart-flood.json).
 
+A showcase can be uploaded from attributes found in either a CSV format file like this:
+```
+dataset_name,timestamp,attribute,value,secondary_value
+climada-litpop-showcase,2024-02-21T08:11:10.725670,entity_type,"showcase",
+climada-litpop-showcase,2024-02-21T08:11:10.725670,name,"climada-litpop-showcase",
+climada-litpop-showcase,2024-02-21T08:11:10.725670,parent_dataset,"climada-litpop-dataset",
+climada-litpop-showcase,2024-02-21T08:11:10.725670,title,"CLIMADA LitPop Methodology Documentation",
+climada-litpop-showcase,2024-02-21T08:11:10.725670,notes,"Click the image to go to the original source for this data",
+climada-litpop-showcase,2024-02-21T08:11:10.725670,url,https://climada-python.readthedocs.io/en/stable/tutorial/climada_entity_LitPop.html,
+climada-litpop-showcase,2024-02-21T08:11:10.725670,image_url,https://github.com/OCHA-DAP/hdx-scraper-climada/blob/main/src/hdx_scraper_climada/output/litpop/litpop-haiti-showcase.png,
+climada-litpop-showcase,2024-02-21T08:11:10.725670,tags,"economics",
+climada-litpop-showcase,2024-02-21T08:11:10.725670,tags,"gross domestic product-gdp",
+climada-litpop-showcase,2024-02-21T08:11:10.725670,tags,"population",
+```
+
+or a JSON file:
+
+```
+{
+    "entity_type": "showcase",
+    "name": "climada-litpop-showcase",
+    "parent_dataset": "climada-litpop-dataset",
+    "title": "CLIMADA LitPop Methodology Documentation",
+    "notes": "Click the image to go to the original source for this data",
+    "url": "https://climada-python.readthedocs.io/en/stable/tutorial/climada_entity_LitPop.html",
+    "image_url": "https://github.com/OCHA-DAP/hdx-scraper-climada/blob/main/src/hdx_scraper_climada/output/litpop/litpop-haiti-showcase.png",
+    "tags": [
+        "economics",
+        "gross domestic product-gdp",
+        "population"
+    ]
+}
+```
+
+Using a commandline like:
+```
+hdx-toolkit showcase --showcase_name=climada-litpop-showcase --hdx_site=stage --attributes_file_path=attributes.csv
+```
 ## Future Work
 
 Potential new features can be found in the [GitHub issue tracker](https://github.com/OCHA-DAP/hdx-cli-toolkit/issues)
@@ -119,4 +157,5 @@ hdx-toolkit get_user_metadata --user=hopkinson --verbose
 hdx-toolkit print --dataset_filter=climada-litpop-dataset
 hdx-toolkit print --dataset_filter=wfp-food-prices-for-nigeria --with_extras
 hdx-toolkit quickcharts --dataset_filter=climada-flood-dataset --hdx_site=stage --resource_name=admin1-summaries-flood.csv --hdx_hxl_preview_file_path=quickchart-flood.json
+hdx-toolkit showcase --showcase_name=climada-litpop-showcase --hdx_site=stage --attributes_file_path=attributes.csv
 ```

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Purpose
+
+Version for this PR: 202*.*.*
+
+- [] [GitHub issue or issues if relevant](https://www.google.com)
+
+## Major file changes
+Describe major file changes in brief
+
+## Minor file changes
+Outline why other files have changed
+
+## Versioning
+
+`hdx-cli-toolkit` uses the CalVer versioning scheme with format YYYY.MM.Micro i.e. 2022.12.1 which is updated manually in `pyproject.toml`. The "Micro" component is simply an integer increased by 1 at each version, starting from 0.
+- [] Version updated in `pyproject.toml` and PR description

--- a/README.md
+++ b/README.md
@@ -108,5 +108,7 @@ PREPREFIX - - environment variable. Value: [YOUR_organization]
 
 Testing uses a mock for the HDX so a live HDX_KEY is not required.
 
+New features should be developed against a GitHub issue on a separate branch with a name starting GH[issue number]_ . `PULL_REQUEST_TEMPLATE.md` should be used in preparing pull requests. Versioning is updated manually in `pyproject.toml` and is described in the template, in brief it is CalVer `YYYY.MM.Micro`.
+
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hdx_cli_toolkit"
-version = "2024.1.1"
+version = "2024.2.1"
 description = "HDX CLI tool kit for commandline interaction with HDX"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/hdx_cli_toolkit/cli.py
+++ b/src/hdx_cli_toolkit/cli.py
@@ -270,15 +270,7 @@ def print_datasets(
 def get_organization_metadata(organization: str, hdx_site: str = "stage", verbose: bool = False):
     """Get an organization id and other metadata"""
     print_banner("Get organization Metadata")
-    try:
-        Configuration.create(
-            user_agent_config_yaml=os.path.join(os.path.expanduser("~"), ".useragents.yaml"),
-            user_agent_lookup="hdx-cli-toolkit",
-            hdx_site=hdx_site,
-            hdx_read_only=False,
-        )
-    except ConfigurationError:
-        pass
+    configure_hdx_connection(hdx_site=hdx_site)
 
     all_organizations = Organization.get_all_organization_names(include_extras=True)
     for an_organization in all_organizations:
@@ -315,15 +307,7 @@ def get_organization_metadata(organization: str, hdx_site: str = "stage", verbos
 def get_user_metadata(user: str, hdx_site: str = "stage", verbose: bool = False):
     """Get user id and other metadata"""
     print_banner("Get User Metadata")
-    try:
-        Configuration.create(
-            user_agent_config_yaml=os.path.join(os.path.expanduser("~"), ".useragents.yaml"),
-            user_agent_lookup="hdx-cli-toolkit",
-            hdx_site=hdx_site,
-            hdx_read_only=False,
-        )
-    except ConfigurationError:
-        pass
+    configure_hdx_connection(hdx_site=hdx_site)
 
     user_list = User.get_all_users(q=user)
     for a_user in user_list:
@@ -429,15 +413,7 @@ def quickcharts(
         f"'{dataset_filter}', resource '{resource_name}'"
     )
     t0 = time.time()
-    try:
-        Configuration.create(
-            user_agent_config_yaml=os.path.join(os.path.expanduser("~"), ".useragents.yaml"),
-            user_agent_lookup="hdx-cli-toolkit",
-            hdx_site=hdx_site,
-            hdx_read_only=False,
-        )
-    except ConfigurationError:
-        pass
+    configure_hdx_connection(hdx_site=hdx_site)
 
     # read the json file
     with open(hdx_hxl_preview_file_path, "r", encoding="utf-8") as json_file:
@@ -530,15 +506,7 @@ def get_filtered_datasets(
     Returns:
         list[Dataset] -- a list of datasets satisfying the selection criteria
     """
-    try:
-        Configuration.create(
-            user_agent_config_yaml=os.path.join(os.path.expanduser("~"), ".useragents.yaml"),
-            user_agent_lookup="hdx-cli-toolkit",
-            hdx_site=hdx_site,
-            hdx_read_only=False,
-        )
-    except ConfigurationError:
-        pass
+    configure_hdx_connection(hdx_site=hdx_site)
 
     if organization != "":
         organization = Organization.read_from_hdx(organization)

--- a/src/hdx_cli_toolkit/cli.py
+++ b/src/hdx_cli_toolkit/cli.py
@@ -27,6 +27,8 @@ from hdx_cli_toolkit.utilities import (
     make_conversion_func,
 )
 
+from hdx_cli_toolkit.hdx_utilities import add_showcase, configure_hdx_connection
+
 
 @click.group()
 def hdx_toolkit() -> None:
@@ -468,6 +470,41 @@ def quickcharts(
         os.remove(temp_yaml_path)
 
     print(f"Quick Chart update took {time.time() - t0:.2f} seconds")
+
+
+@hdx_toolkit.command(name="showcase")
+@click.option(
+    "--showcase_name",
+    is_flag=False,
+    default="*",
+    help="showcase name",
+)
+@click.option(
+    "--hdx_site",
+    is_flag=False,
+    default="stage",
+    help="an hdx_site value {stage|prod}",
+)
+@click.option(
+    "--attributes_file_path",
+    is_flag=False,
+    default="stage",
+    help="path to the attributes file describing the showcase",
+)
+def showcase(
+    showcase_name: str = "",
+    hdx_site: str = "stage",
+    attributes_file_path: str = "",
+):
+    """Upload showcase to HDX"""
+    print_banner("showcase")
+    print(f"Adding showcase defined at '{attributes_file_path}'")
+    t0 = time.time()
+    statuses = add_showcase(showcase_name, hdx_site, attributes_file_path)
+    for status in statuses:
+        print(status, flush=True)
+
+    print(f"Showcase update took {time.time() - t0:.2f} seconds")
 
 
 def get_filtered_datasets(

--- a/src/hdx_cli_toolkit/hdx_utilities.py
+++ b/src/hdx_cli_toolkit/hdx_utilities.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+import os
+from hdx.api.configuration import Configuration, ConfigurationError
+from hdx.data.dataset import Dataset
+from hdx.data.showcase import Showcase
+
+from hdx_cli_toolkit.utilities import read_attributes
+
+
+def add_showcase(showcase_name: str, hdx_site: str, attributes_file_path: str):
+    configure_hdx_connection(hdx_site)
+    statuses = []
+    showcase_attributes = read_attributes(showcase_name, attributes_filepath=attributes_file_path)
+    showcase = Showcase(
+        {
+            "name": showcase_attributes["name"],
+            "title": showcase_attributes["title"],
+            "notes": showcase_attributes["notes"],
+            "url": showcase_attributes["url"],
+            "image_url": showcase_attributes["image_url"],
+        }
+    )
+    added_tags, unadded_tags = showcase.add_tags(showcase_attributes["tags"])
+    statuses.append(f"{len(added_tags)} of {len(showcase_attributes['tags'])} showcase tags added")
+    if len(unadded_tags) != 0:
+        statuses.append(f"Rejected showcase tags: {unadded_tags}")
+
+    showcase.create_in_hdx()
+    dataset = Dataset.read_from_hdx(showcase_attributes["parent_dataset"])
+    showcase.add_dataset(dataset)
+    statuses.append(f"Added dataset '{dataset['name']}' to showcase '{showcase_name}'")
+
+    return statuses
+
+
+def configure_hdx_connection(hdx_site: str):
+    try:
+        Configuration.create(
+            user_agent_config_yaml=os.path.join(os.path.expanduser("~"), ".useragents.yaml"),
+            user_agent_lookup="hdx-cli-toolkit",
+            hdx_site=hdx_site,
+            hdx_read_only=False,
+        )
+    except ConfigurationError:
+        pass

--- a/src/hdx_cli_toolkit/utilities.py
+++ b/src/hdx_cli_toolkit/utilities.py
@@ -203,3 +203,31 @@ def make_conversion_func(value: Any) -> tuple[Callable | None, str]:
         conversion_func = None
 
     return conversion_func, value_type.__name__
+
+
+def read_attributes(dataset_name: str, attributes_filepath: str) -> dict:
+    """A function for reading attributes from a standard attributes.csv file with columns:
+    dataset_name,timestamp,attribute,value,secondary_value
+
+    Arguments:
+        dataset_name {str} -- the name of the dataset for which attributes are required
+
+    Returns:
+        dict -- a dictionary containing the attributes
+    """
+    with open(attributes_filepath, "r", encoding="UTF-8") as attributes_filehandle:
+        attribute_rows = csv.DictReader(attributes_filehandle)
+
+        attributes = {}
+        for row in attribute_rows:
+            if row["dataset_name"] != dataset_name:
+                continue
+            if row["attribute"] in ["resource", "skip_country", "showcase", "tags"]:
+                if row["attribute"] not in attributes:
+                    attributes[row["attribute"]] = [row["value"]]
+                else:
+                    attributes[row["attribute"]].append(row["value"])
+            else:
+                attributes[row["attribute"]] = row["value"]
+
+    return attributes

--- a/src/hdx_cli_toolkit/utilities.py
+++ b/src/hdx_cli_toolkit/utilities.py
@@ -223,7 +223,21 @@ def read_attributes(dataset_name: str, attributes_filepath: str) -> dict:
         with open(attributes_filepath, "r", encoding="UTF-8") as attributes_filehandle:
             attribute_rows = csv.DictReader(attributes_filehandle)
             attributes = {}
+
             for row in attribute_rows:
+                if list(row.keys()) != [
+                    "dataset_name",
+                    "timestamp",
+                    "attribute",
+                    "value",
+                    "secondary_value",
+                ]:
+                    print(
+                        "Attributes.csv file must have columns: "
+                        "dataset_name, timestamp, attribute, value, secondary_value"
+                    )
+                    return attributes
+
                 if row["dataset_name"] != dataset_name:
                     continue
                 if row["attribute"] in ["resource", "skip_country", "showcase", "tags"]:

--- a/tests/fixtures/attributes-list.json
+++ b/tests/fixtures/attributes-list.json
@@ -1,0 +1,16 @@
+[
+    {
+        "entity_type": "showcase",
+        "name": "climada-litpop-showcase",
+        "parent_dataset": "climada-litpop-dataset",
+        "title": "CLIMADA LitPop Methodology Documentation",
+        "notes": "Click the image to go to the original source for this data",
+        "url": "https://climada-python.readthedocs.io/en/stable/tutorial/climada_entity_LitPop.html",
+        "image_url": "https://github.com/OCHA-DAP/hdx-scraper-climada/blob/main/src/hdx_scraper_climada/output/litpop/litpop-haiti-showcase.png",
+        "tags": [
+            "economics",
+            "gross domestic product-gdp",
+            "population"
+        ]
+    }
+]

--- a/tests/fixtures/attributes-single.json
+++ b/tests/fixtures/attributes-single.json
@@ -1,0 +1,14 @@
+{
+    "entity_type": "showcase",
+    "name": "climada-litpop-showcase",
+    "parent_dataset": "climada-litpop-dataset",
+    "title": "CLIMADA LitPop Methodology Documentation",
+    "notes": "Click the image to go to the original source for this data",
+    "url": "https://climada-python.readthedocs.io/en/stable/tutorial/climada_entity_LitPop.html",
+    "image_url": "https://github.com/OCHA-DAP/hdx-scraper-climada/blob/main/src/hdx_scraper_climada/output/litpop/litpop-haiti-showcase.png",
+    "tags": [
+        "economics",
+        "gross domestic product-gdp",
+        "population"
+    ]
+}

--- a/tests/fixtures/attributes.csv
+++ b/tests/fixtures/attributes.csv
@@ -1,0 +1,11 @@
+dataset_name,timestamp,attribute,value,secondary_value
+climada-litpop-showcase,2024-02-21T08:11:10.725670,entity_type,"showcase",
+climada-litpop-showcase,2024-02-21T08:11:10.725670,name,"climada-litpop-showcase",
+climada-litpop-showcase,2024-02-21T08:11:10.725670,parent_dataset,"climada-litpop-dataset",
+climada-litpop-showcase,2024-02-21T08:11:10.725670,title,"CLIMADA LitPop Methodology Documentation",
+climada-litpop-showcase,2024-02-21T08:11:10.725670,notes,"Click the image to go to the original source for this data",
+climada-litpop-showcase,2024-02-21T08:11:10.725670,url,https://climada-python.readthedocs.io/en/stable/tutorial/climada_entity_LitPop.html,
+climada-litpop-showcase,2024-02-21T08:11:10.725670,image_url,https://github.com/OCHA-DAP/hdx-scraper-climada/blob/main/src/hdx_scraper_climada/output/litpop/litpop-haiti-showcase.png,
+climada-litpop-showcase,2024-02-21T08:11:10.725670,tags,"economics",
+climada-litpop-showcase,2024-02-21T08:11:10.725670,tags,"gross domestic product-gdp",
+climada-litpop-showcase,2024-02-21T08:11:10.725670,tags,"population",

--- a/tests/test_hdx_utilities.py
+++ b/tests/test_hdx_utilities.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+import os
+from unittest import mock
+from unittest.mock import patch
+
+from hdx_cli_toolkit.hdx_utilities import add_showcase
+
+
+# @patch("hdx.data.showcase.Showcase")
+@patch("hdx_cli_toolkit.hdx_utilities.Showcase")
+@patch("hdx.data.dataset.Dataset.read_from_hdx")
+def test_add_showcase(mock_hdx, mock_showcase):
+    attributes_file_path = os.path.join(os.path.dirname(__file__), "fixtures", "attributes.csv")
+    showcase_name = "climada-litpop-showcase"
+    mock_showcase().add_tags.return_value = (mock.MagicMock(), mock.MagicMock())
+    mock_hdx.return_value = {"name": "mock name"}
+
+    statuses = add_showcase(showcase_name, "stage", attributes_file_path)
+
+    assert statuses == [
+        "0 of 3 showcase tags added",
+        "Added dataset 'mock name' to showcase 'climada-litpop-showcase'",
+    ]
+    mock_showcase().add_tags.assert_called_with(
+        ["economics", "gross domestic product-gdp", "population"]
+    )
+    mock_showcase().create_in_hdx.assert_called_with()
+    mock_showcase().add_dataset.assert_called_with({"name": "mock name"})

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -7,6 +7,11 @@ import os
 from hdx_cli_toolkit.utilities import write_dictionary, censor_secret, read_attributes
 
 
+ATTRIBUTES_FILE_PATH = os.path.join(os.path.dirname(__file__), "fixtures", "attributes.csv")
+DATASET_NAME = "climada-litpop-showcase"
+REFERENCE_ATTRIBUTES = read_attributes(DATASET_NAME, attributes_filepath=ATTRIBUTES_FILE_PATH)
+
+
 def test_write_dictionary_to_local_file():
     temp_file_path = os.path.join(os.path.dirname(__file__), "fixtures", "test.csv")
     if os.path.isfile(temp_file_path):
@@ -40,9 +45,29 @@ def test_censor_long_secret():
 
 
 def test_read_attributes():
-    attributes_file_path = os.path.join(os.path.dirname(__file__), "fixtures", "attributes.csv")
-    dataset_name = "climada-litpop-showcase"
-    dataset_attributes = read_attributes(dataset_name, attributes_filepath=attributes_file_path)
+    assert len(REFERENCE_ATTRIBUTES["tags"]) == 3
+    assert REFERENCE_ATTRIBUTES["parent_dataset"] == "climada-litpop-dataset"
 
-    assert len(dataset_attributes["tags"]) == 3
-    assert dataset_attributes["parent_dataset"] == "climada-litpop-dataset"
+
+def test_read_attributes_json():
+    attributes_json_file_path = os.path.join(
+        os.path.dirname(__file__), "fixtures", "attributes-single.json"
+    )
+
+    dataset_attributes = read_attributes(
+        DATASET_NAME, attributes_filepath=attributes_json_file_path
+    )
+
+    assert REFERENCE_ATTRIBUTES == dataset_attributes
+
+
+def test_read_attributes_json_list():
+    attributes_json_list_file_path = os.path.join(
+        os.path.dirname(__file__), "fixtures", "attributes-list.json"
+    )
+
+    dataset_attributes = read_attributes(
+        DATASET_NAME, attributes_filepath=attributes_json_list_file_path
+    )
+
+    assert REFERENCE_ATTRIBUTES == dataset_attributes

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -4,7 +4,7 @@
 import csv
 import os
 
-from hdx_cli_toolkit.utilities import write_dictionary, censor_secret
+from hdx_cli_toolkit.utilities import write_dictionary, censor_secret, read_attributes
 
 
 def test_write_dictionary_to_local_file():
@@ -37,3 +37,12 @@ def test_censor_short_secret():
 def test_censor_long_secret():
     censored_secret = censor_secret("ABCDEF0123456789")
     assert censored_secret == "******0123456789"
+
+
+def test_read_attributes():
+    attributes_file_path = os.path.join(os.path.dirname(__file__), "fixtures", "attributes.csv")
+    dataset_name = "climada-litpop-showcase"
+    dataset_attributes = read_attributes(dataset_name, attributes_filepath=attributes_file_path)
+
+    assert len(dataset_attributes["tags"]) == 3
+    assert dataset_attributes["parent_dataset"] == "climada-litpop-dataset"


### PR DESCRIPTION
## Purpose

Version for this PR: 2024.2.1

- #8 

## Major file changes
A new `hdx_utilities.py` file is created to hold the showcase code, along with a `test_hdx_utilities.py` file for tests. `cli.py` gets a new command function. The `utilities.py` file gains a `read_attributes` function to facilitate loading metadata for the showcase.

## Minor file changes
Several test fixtures are added and documentation is updated.

## Versioning

`hdx-cli-toolkit` uses the CalVer versioning scheme with format YYYY.MM.Micro i.e. 2022.12.1 which is updated manually in `pyproject.toml`. The "Micro" component is simply an integer increased by 1 at each version, starting from 0.
- [x] Version updated in `pyproject.toml` and PR description
