### PR TITLE
GH9 - Refactor and Publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,30 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get history and tags for versioning to work
+      run: |
+        git fetch --prune --unshallow
+        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade hatch
+    - name: Build and publish with hatch
+      env:
+        HATCH_INDEX_USER: ${{secrets.HATCH_INDEX_USER}}
+        HATCH_INDEX_AUTH: ${{secrets.HATCH_INDEX_AUTH}}
+      run: |
+        make publish

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ cov.xml
 tests/fixtures/test.csv
 
 src/temp/
+
+dist/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Michael Rans
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,7 @@ lint:
 	pylint --rcfile=config/.pylintrc src/ || true
 unit_tests:
 	pytest --cov=hdx_cli_toolkit --cov-config=config/.coveragerc tests/
+publish:
+	rm -rf build dist *.egg-info
+	hatch build
+	hatch publish -r test

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ unit_tests:
 publish:
 	rm -rf build dist *.egg-info
 	hatch build
-	hatch publish -r test
+	hatch publish

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@ Version for this PR: 202*.*.*
 
 - [] [GitHub issue or issues if relevant](https://www.google.com)
 
+
 ## Major file changes
 Describe major file changes in brief
 
@@ -14,3 +15,4 @@ Outline why other files have changed
 
 `hdx-cli-toolkit` uses the CalVer versioning scheme with format YYYY.MM.Micro i.e. 2022.12.1 which is updated manually in `pyproject.toml`. The "Micro" component is simply an integer increased by 1 at each version, starting from 0.
 - [] Version updated in `pyproject.toml` and PR description
+- [] Update README.md and DEMO.md with any new CLI commands

--- a/README.md
+++ b/README.md
@@ -2,27 +2,32 @@
 
 ## Overview
 
-This toolkit is intended to provide a commandline interface to HDX to allow for bulk modification operations and other administrative activities, in the first instance to carry out a bulk quarantine action on all the datasets in an organization. It is inspired by [hdx-update-cods-level](https://github.com/b-j-mills/hdx-update-cods-level/tree/main).
+This toolkit provides a commandline interface to the [Humanitarian Data Exchange](https://data.humdata.org/) (HDX) to allow for bulk modification operations and other administrative activities such as getting `id` values for users and organization. It is useful for those managing HDX and developers building data pipelines for HDX. The currently supported commands are as follows:
+
+```
+  configuration              Print configuration information to terminal
+  get_organization_metadata  Get an organization id and other metadata
+  get_user_metadata          Get user id and other metadata
+  list                       List datasets in HDX
+  print                      Print datasets in HDX to the terminal
+  quickcharts                Upload QuickChart JSON description to HDX
+  showcase                   Upload showcase to HDX
+  update                     Update datasets in HDX
+  update_resource            Update a resource in HDX
+```
+
+It is a thin wrapper to the [hdx-python-api](https://github.com/OCHA-DAP/hdx-python-api) written by Mike Rans.
+
+The library requires some configuration, described below, to authenticate to the HDX instance.
 
 ## Installation
-`hdx-cli-toolkit` is a Python application. 
+`hdx-cli-toolkit` is a Python application published to the PyPI package repository, therefore it can be installed easily with:
 
-For developers the code should be cloned installed from the [GitHub repo](https://github.com/OCHA-DAP/hdx-cli-toolkit), and a virtual enviroment created:
+```pip install hdx-cli-toolkit```
 
-```shell
-python -m venv venv
-source venv/Scripts/activate
-```
+Users may prefer to make a global, isolated installation using [pipx](https://pypi.org/project/pipx/) which will make the `hdx-toolkit` commands available across their projects:
 
-And then an editable installation created:
-
-```shell
-pip install -e .
-```
-
-For users the best route is probably to use [pipx](https://pypi.org/project/pipx/) to install which will provide `hdx-toolkit` globally in its own environment.
-
-In either case there is a small amount of configuration required.
+```pipx install hdx-cli-toolkit```
 
 `hdx-cli-toolkit` uses the `hdx-python-api` library, this requires the following to be added to a file called `.hdx_configuration.yaml` in the user's home directory.
 
@@ -37,7 +42,6 @@ hdx-cli-toolkit:
     preprefix: [YOUR_ORGANIZATION]
     user_agent: hdx_cli_toolkit_ih
 ```
-
 
 ## Usage
 
@@ -74,6 +78,21 @@ A detailed walk through of commands can be found in the [DEMO.md](DEMO.md) file
 
 ## Contributions
 
+For developers the code should be cloned installed from the [GitHub repo](https://github.com/OCHA-DAP/hdx-cli-toolkit), and a virtual enviroment created:
+
+```shell
+python -m venv venv
+source venv/Scripts/activate
+```
+
+And then an editable installation created:
+
+```shell
+pip install -e .
+```
+
+The library is then configured, as described above.
+
 This project users a GitHub Action to run tests and linting. It requires the following environment variables/secrets to be set in the `test` environment:
 
 ```
@@ -84,9 +103,7 @@ USER_AGENT - environment variable. Value: hdx_cli_toolkit_gha
 PREPREFIX - - environment variable. Value: [YOUR_organization]
 ```
 
-Testing uses a mock for the HDX so a live HDX_KEY is not required.
+Most tests use mocking in place of HDX, although the `test_integration.py` suite runs against the `stage` server.
 
 New features should be developed against a GitHub issue on a separate branch with a name starting GH[issue number]_ . `PULL_REQUEST_TEMPLATE.md` should be used in preparing pull requests. Versioning is updated manually in `pyproject.toml` and is described in the template, in brief it is CalVer `YYYY.MM.Micro`.
-
-
 

--- a/README.md
+++ b/README.md
@@ -107,3 +107,11 @@ Most tests use mocking in place of HDX, although the `test_integration.py` suite
 
 New features should be developed against a GitHub issue on a separate branch with a name starting `GH[issue number]_`. `PULL_REQUEST_TEMPLATE.md` should be used in preparing pull requests. Versioning is updated manually in `pyproject.toml` and is described in the template, in brief it is CalVer `YYYY.MM.Micro`.
 
+## Publication
+
+Publication to PyPI is done using `hatch` which requires the following environment variables:
+
+```
+HATCH_INDEX_USER - set to `__token__`
+HATCH_INDEX_AUTH - API key provided by PyPI
+```

--- a/README.md
+++ b/README.md
@@ -16,18 +16,18 @@ This toolkit provides a commandline interface to the [Humanitarian Data Exchange
   update_resource            Update a resource in HDX
 ```
 
-It is a thin wrapper to the [hdx-python-api](https://github.com/OCHA-DAP/hdx-python-api) written by Mike Rans.
+It is a thin wrapper to the [hdx-python-api](https://github.com/OCHA-DAP/hdx-python-api) library written by Mike Rans.
 
 The library requires some configuration, described below, to authenticate to the HDX instance.
 
 ## Installation
 `hdx-cli-toolkit` is a Python application published to the PyPI package repository, therefore it can be installed easily with:
 
-```pip install hdx-cli-toolkit```
+```pip install hdx_cli_toolkit```
 
 Users may prefer to make a global, isolated installation using [pipx](https://pypi.org/project/pipx/) which will make the `hdx-toolkit` commands available across their projects:
 
-```pipx install hdx-cli-toolkit```
+```pipx install hdx_cli_toolkit```
 
 `hdx-cli-toolkit` uses the `hdx-python-api` library, this requires the following to be added to a file called `.hdx_configuration.yaml` in the user's home directory.
 
@@ -36,7 +36,7 @@ hdx_key_stage: "[hdx_key from the staging HDX site]"
 hdx_key: "[hdx_key from the prod HDX site]"
 ```
 
-A user agent (`hdx_cli_toolkit_*`) is specified in the `~/.useragents.yaml` file the * replaced with the users initials.
+A user agent (`hdx_cli_toolkit_*`) is specified in the `~/.useragents.yaml` file with the * replaced with the users initials.
 ```
 hdx-cli-toolkit:
     preprefix: [YOUR_ORGANIZATION]
@@ -93,7 +93,7 @@ pip install -e .
 
 The library is then configured, as described above.
 
-This project users a GitHub Action to run tests and linting. It requires the following environment variables/secrets to be set in the `test` environment:
+This project uses a GitHub Action to run tests and linting. It requires the following environment variables/secrets to be set in the `test` environment:
 
 ```
 HDX_KEY - secret. Value: fake secret
@@ -105,5 +105,5 @@ PREPREFIX - - environment variable. Value: [YOUR_organization]
 
 Most tests use mocking in place of HDX, although the `test_integration.py` suite runs against the `stage` server.
 
-New features should be developed against a GitHub issue on a separate branch with a name starting GH[issue number]_ . `PULL_REQUEST_TEMPLATE.md` should be used in preparing pull requests. Versioning is updated manually in `pyproject.toml` and is described in the template, in brief it is CalVer `YYYY.MM.Micro`.
+New features should be developed against a GitHub issue on a separate branch with a name starting `GH[issue number]_`. `PULL_REQUEST_TEMPLATE.md` should be used in preparing pull requests. Versioning is updated manually in `pyproject.toml` and is described in the template, in brief it is CalVer `YYYY.MM.Micro`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "hdx_cli_toolkit"
-version = "2024.3.2"
+version = "2024.3.3"
 description = "HDX CLI tool kit for commandline interaction with HDX"
-readme = "README.md"
+readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
 requires-python = ">=3.11"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [project]
 name = "hdx_cli_toolkit"
-version = "2024.3.1"
+version = "2024.3.2"
 description = "HDX CLI tool kit for commandline interaction with HDX"
 readme = "README.md"
+license = {file = "LICENSE"}
 requires-python = ">=3.11"
 authors = [
   {email = "ian.hopkinson@un.org"},
@@ -14,6 +15,7 @@ dependencies = [
   "hdx-python-country",
   "quantulum3[classifier]", # This stops the UserWarning but has a number of large dependencies
   "click",
+  "hatch",
   "pytest",
   "pytest-cov",
   "black==23.10.0",

--- a/src/hdx_cli_toolkit/cli.py
+++ b/src/hdx_cli_toolkit/cli.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import datetime
 import fnmatch
 import json
 import os
@@ -14,11 +13,10 @@ import yaml
 import click
 from click.decorators import FC
 
-from hdx.api.configuration import Configuration, ConfigurationError
+from hdx.api.configuration import ConfigurationError
 from hdx.data.hdxobject import HDXError
 from hdx.data.dataset import Dataset
 from hdx.data.organization import Organization
-from hdx.data.resource_view import ResourceView
 from hdx.data.user import User
 from hdx.utilities.path import script_dir_plus_file
 
@@ -27,12 +25,15 @@ from hdx_cli_toolkit.utilities import (
     print_table_from_list_of_dicts,
     censor_secret,
     make_conversion_func,
+    print_banner,
 )
 
 from hdx_cli_toolkit.hdx_utilities import (
     add_showcase,
     configure_hdx_connection,
     update_resource_in_hdx,
+    get_filtered_datasets,
+    decorate_dataset_with_extras,
 )
 
 
@@ -561,114 +562,3 @@ def update_resource(
         print(status, flush=True)
 
     print(f"Resource update took {time.time() - t0:.2f} seconds")
-
-
-def get_filtered_datasets(
-    organization: str = "",
-    dataset_filter: str = "*",
-    query: str = None,
-    hdx_site: str = "stage",
-    verbose: bool = True,
-) -> list[Dataset]:
-    """A function to return a list of datasets selected by some selection criteria based on
-    organization, dataset name, or CKAN query strings. The verbose flag is provided so
-    summary output can be suppressed for output to file in the print command.
-
-    Keyword Arguments:
-        organization {str} -- an organization name (default: {""})
-        key {str} -- _description_ (default: {"private"})
-        value {str} -- _description_ (default: {"value"})
-        dataset_filter {str} -- a filter for dataset name, can contain wildcards (default: {"*"})
-        query {str} -- a query string to use in the CKAN search API (default: {None})
-        hdx_site {str} -- target HDX site {prod|stage} (default: {"stage"})
-        verbose {bool} -- if True prints summary information (default: {True})
-
-    Returns:
-        list[Dataset] -- a list of datasets satisfying the selection criteria
-    """
-    configure_hdx_connection(hdx_site=hdx_site)
-
-    if organization != "":
-        organization = Organization.read_from_hdx(organization)
-        datasets = organization.get_datasets(include_private=True)
-    elif query is not None:
-        datasets = Dataset.search_in_hdx(query=query)
-        organization = {"display_name": "", "name": ""}
-    else:
-        dataset = Dataset.read_from_hdx(dataset_filter)
-        if dataset is None:
-            datasets = []
-            organization = {"display_name": "", "name": ""}
-        else:
-            datasets = [dataset]
-            organization = dataset.get_organization()
-            organization = {"display_name": organization["title"], "name": organization["name"]}
-
-    filtered_datasets = []
-    for dataset in datasets:
-        if fnmatch.fnmatch(dataset["name"], dataset_filter):
-            filtered_datasets.append(dataset)
-
-    if verbose:
-        print(Configuration.read().hdx_site, flush=True)
-        print(
-            f"Found {len(filtered_datasets)} datasets for organization "
-            f"'{organization['display_name']} "
-            f"({organization['name']})' matching filter conditions:",
-            flush=True,
-        )
-
-    return filtered_datasets
-
-
-def decorate_dataset_with_extras(dataset: Dataset) -> dict:
-    """A function to add resource, quickcharts (resource_view) and showcases keys to a dataset
-    dictionary representation for the print command. fs_check_info and hxl_preview_config are
-    converted from JSON objects serialised as single strings to dictionaries to make printed output
-    more readable. This decoration means that the dataset dictionary cannot be uploaded to HDX.
-
-    Arguments:
-        dataset {Dataset} -- a Dataset object to process
-
-    Returns:
-        dict -- a dictionary containing the dataset metadata
-    """
-    output_dict = dataset.data
-    resources = dataset.get_resources()
-    output_dict["resources"] = []
-    for resource in resources:
-        resource_dict = resource.data
-        if "fs_check_info" in resource_dict:
-            resource_dict["fs_check_info"] = json.loads(resource_dict["fs_check_info"])
-        dataset_quickcharts = ResourceView.get_all_for_resource(resource_dict["id"])
-        resource_dict["quickcharts"] = []
-        if quickcharts is not None:
-            for quickchart in dataset_quickcharts:
-                quickchart_dict = quickchart.data
-                if "hxl_preview_config" in quickchart_dict:
-                    quickchart_dict["hxl_preview_config"] = json.loads(
-                        quickchart_dict["hxl_preview_config"]
-                    )
-                resource_dict["quickcharts"].append(quickchart_dict)
-        output_dict["resources"].append(resource_dict)
-
-    showcases = dataset.get_showcases()
-    output_dict["showcases"] = [x.data for x in showcases]
-
-    return output_dict
-
-
-def print_banner(action: str):
-    """Simple function to output a banner to console, uses click's secho command but not colour
-    because the underlying colorama does not output correctly to git-bash terminals.
-
-    Arguments:
-        action {str} -- _description_
-    """
-    title = f"HDX CLI toolkit - {action}"
-    timestamp = f"Invoked at: {datetime.datetime.now().isoformat()}"
-    width = max(len(title), len(timestamp))
-    click.secho((width + 4) * "*", bold=True)
-    click.secho(f"* {title:<{width}} *", bold=True)
-    click.secho(f"* {timestamp:<{width}} *", bold=True)
-    click.secho((width + 4) * "*", bold=True)

--- a/src/hdx_cli_toolkit/cli.py
+++ b/src/hdx_cli_toolkit/cli.py
@@ -27,6 +27,7 @@ from hdx_cli_toolkit.utilities import (
 
 from hdx_cli_toolkit.hdx_utilities import (
     add_showcase,
+    add_quickcharts,
     get_organizations_from_hdx,
     get_users_from_hdx,
     configure_hdx_connection,
@@ -429,37 +430,9 @@ def quickcharts(
         f"'{dataset_filter}', resource '{resource_name}'"
     )
     t0 = time.time()
-    configure_hdx_connection(hdx_site=hdx_site)
+    status = add_quickcharts(dataset_filter, hdx_site, resource_name, hdx_hxl_preview_file_path)
 
-    # read the json file
-    with open(hdx_hxl_preview_file_path, "r", encoding="utf-8") as json_file:
-        recipe = json.load(json_file)
-    # extract appropriate keys
-    processed_recipe = {
-        "description": "",
-        "title": "Quick Charts",
-        "view_type": "hdx_hxl_preview",
-        "hxl_preview_config": "",
-    }
-
-    # convert the configuration to a string
-    stringified_config = json.dumps(
-        recipe["hxl_preview_config"], indent=None, separators=(",", ":")
-    )
-    processed_recipe["hxl_preview_config"] = stringified_config
-    # write out yaml to a temp file
-    temp_yaml_path = f"{hdx_hxl_preview_file_path}.temp.yaml"
-    with open(temp_yaml_path, "w", encoding="utf-8") as yaml_file:
-        yaml.dump(processed_recipe, yaml_file)
-
-    dataset = Dataset.read_from_hdx(dataset_filter)
-
-    dataset.generate_quickcharts(resource=resource_name, path=temp_yaml_path)
-    dataset.update_in_hdx(update_resources=False, hxl_update=False)
-
-    # delete the temp file
-    if os.path.exists(temp_yaml_path):
-        os.remove(temp_yaml_path)
+    print(status, flush=True)
 
     print(f"Quick Chart update took {time.time() - t0:.2f} seconds")
 

--- a/src/hdx_cli_toolkit/cli.py
+++ b/src/hdx_cli_toolkit/cli.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import fnmatch
 import json
 import os
 import time
@@ -16,8 +15,6 @@ from click.decorators import FC
 from hdx.api.configuration import ConfigurationError
 from hdx.data.hdxobject import HDXError
 from hdx.data.dataset import Dataset
-from hdx.data.organization import Organization
-from hdx.data.user import User
 from hdx.utilities.path import script_dir_plus_file
 
 from hdx_cli_toolkit.utilities import (
@@ -30,6 +27,8 @@ from hdx_cli_toolkit.utilities import (
 
 from hdx_cli_toolkit.hdx_utilities import (
     add_showcase,
+    get_organizations_from_hdx,
+    get_users_from_hdx,
     configure_hdx_connection,
     update_resource_in_hdx,
     get_filtered_datasets,
@@ -292,17 +291,15 @@ def get_organization_metadata(organization: str, hdx_site: str = "stage", verbos
     print_banner("Get organization Metadata")
     configure_hdx_connection(hdx_site=hdx_site)
 
-    all_organizations = Organization.get_all_organization_names(include_extras=True)
-    for an_organization in all_organizations:
-        if fnmatch.fnmatch(an_organization, f"*{organization}*"):
-            organization_metadata = Organization.read_from_hdx(an_organization)
-            if verbose:
-                print(json.dumps(organization_metadata.data, indent=2), flush=True)
-            else:
-                print(
-                    f"{organization_metadata['name']:<50.50}: {organization_metadata['id']}",
-                    flush=True,
-                )
+    filtered_organizations = get_organizations_from_hdx(organization, hdx_site=hdx_site)
+    for filtered_organization in filtered_organizations:
+        if verbose:
+            print(json.dumps(filtered_organization.data, indent=2), flush=True)
+        else:
+            print(
+                f"{organization['name']:<50.50}: {filtered_organization['id']}",
+                flush=True,
+            )
 
 
 @hdx_toolkit.command(name="get_user_metadata")
@@ -327,9 +324,8 @@ def get_organization_metadata(organization: str, hdx_site: str = "stage", verbos
 def get_user_metadata(user: str, hdx_site: str = "stage", verbose: bool = False):
     """Get user id and other metadata"""
     print_banner("Get User Metadata")
-    configure_hdx_connection(hdx_site=hdx_site)
 
-    user_list = User.get_all_users(q=user)
+    user_list = get_users_from_hdx(user, hdx_site=hdx_site)
     for a_user in user_list:
         if verbose:
             print(json.dumps(a_user.data, indent=2), flush=True)

--- a/src/hdx_cli_toolkit/hdx_utilities.py
+++ b/src/hdx_cli_toolkit/hdx_utilities.py
@@ -11,6 +11,7 @@ from hdx.data.resource_view import ResourceView
 from hdx.data.dataset import Dataset
 from hdx.data.showcase import Showcase
 from hdx.data.resource import Resource
+from hdx.data.user import User
 
 from hdx_cli_toolkit.utilities import read_attributes
 
@@ -71,6 +72,26 @@ def get_filtered_datasets(
         )
 
     return filtered_datasets
+
+
+def get_organizations_from_hdx(organization: str, hdx_site: str = "stage"):
+    configure_hdx_connection(hdx_site)
+    filtered_organizations = []
+    all_organizations = Organization.get_all_organization_names(include_extras=True)
+    for an_organization in all_organizations:
+        if fnmatch.fnmatch(an_organization, f"*{organization}*"):
+            organization_metadata = Organization.read_from_hdx(an_organization)
+            filtered_organizations.append(organization_metadata)
+
+    return filtered_organizations
+
+
+def get_users_from_hdx(user: str, hdx_site: str = "stage"):
+    configure_hdx_connection(hdx_site=hdx_site)
+
+    user_list = User.get_all_users(q=user)
+
+    return user_list
 
 
 def decorate_dataset_with_extras(dataset: Dataset) -> dict:

--- a/src/hdx_cli_toolkit/utilities.py
+++ b/src/hdx_cli_toolkit/utilities.py
@@ -3,11 +3,14 @@
 
 import csv
 import dataclasses
+import datetime
 import json
 import os
 
 from collections.abc import Callable
 from typing import Any
+
+import click
 
 
 def write_dictionary(
@@ -263,3 +266,19 @@ def read_attributes(dataset_name: str, attributes_filepath: str) -> dict:
         attributes = {}
 
     return attributes
+
+
+def print_banner(action: str):
+    """Simple function to output a banner to console, uses click's secho command but not colour
+    because the underlying colorama does not output correctly to git-bash terminals.
+
+    Arguments:
+        action {str} -- _description_
+    """
+    title = f"HDX CLI toolkit - {action}"
+    timestamp = f"Invoked at: {datetime.datetime.now().isoformat()}"
+    width = max(len(title), len(timestamp))
+    click.secho((width + 4) * "*", bold=True)
+    click.secho(f"* {title:<{width}} *", bold=True)
+    click.secho(f"* {timestamp:<{width}} *", bold=True)
+    click.secho((width + 4) * "*", bold=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,12 +3,11 @@
 
 import os
 from unittest import mock
-from unittest.mock import patch
 from click.testing import CliRunner
 
 from hdx.data.dataset import Dataset
 from hdx.api.configuration import Configuration, ConfigurationError
-from hdx_cli_toolkit.cli import list_datasets, get_filtered_datasets
+from hdx_cli_toolkit.cli import list_datasets
 
 try:
     Configuration.create(
@@ -45,39 +44,6 @@ def test_list_datasets(mock_hdx, json_fixture):
     )
 
     cli_test_template(command, cli_arguments, expected_output, forbidden_output="")
-
-
-@patch("hdx.data.dataset.Dataset.search_in_hdx")
-def test_get_filtered_datasets_1(mock_hdx):
-    _ = get_filtered_datasets(
-        organization="",
-        dataset_filter="*",
-        query="archived:true",
-    )
-
-    mock_hdx.assert_called_with(query="archived:true")
-
-
-@patch("hdx.data.organization.Organization.read_from_hdx")
-def test_get_filtered_datasets_2(mock_hdx):
-    _ = get_filtered_datasets(
-        organization="healthsites",
-        dataset_filter="*",
-        query=None,
-    )
-
-    mock_hdx.assert_called_with("healthsites")
-
-
-@patch("hdx.data.dataset.Dataset.read_from_hdx")
-def test_get_filtered_datasets_3(mock_hdx):
-    _ = get_filtered_datasets(
-        organization="",
-        dataset_filter="a-full-dataset-name",
-        query=None,
-    )
-
-    mock_hdx.assert_called_with("a-full-dataset-name")
 
 
 def cli_test_template(command, cli_arguments, expected_output, forbidden_output=""):

--- a/tests/test_hdx_utilities.py
+++ b/tests/test_hdx_utilities.py
@@ -5,7 +5,7 @@ import os
 from unittest import mock
 from unittest.mock import patch
 
-from hdx_cli_toolkit.hdx_utilities import add_showcase
+from hdx_cli_toolkit.hdx_utilities import add_showcase, get_filtered_datasets
 
 
 # @patch("hdx.data.showcase.Showcase")
@@ -28,3 +28,36 @@ def test_add_showcase(mock_hdx, mock_showcase):
     )
     mock_showcase().create_in_hdx.assert_called_with()
     mock_showcase().add_dataset.assert_called_with({"name": "mock name"})
+
+
+@patch("hdx.data.dataset.Dataset.search_in_hdx")
+def test_get_filtered_datasets_1(mock_hdx):
+    _ = get_filtered_datasets(
+        organization="",
+        dataset_filter="*",
+        query="archived:true",
+    )
+
+    mock_hdx.assert_called_with(query="archived:true")
+
+
+@patch("hdx.data.organization.Organization.read_from_hdx")
+def test_get_filtered_datasets_2(mock_hdx):
+    _ = get_filtered_datasets(
+        organization="healthsites",
+        dataset_filter="*",
+        query=None,
+    )
+
+    mock_hdx.assert_called_with("healthsites")
+
+
+@patch("hdx.data.dataset.Dataset.read_from_hdx")
+def test_get_filtered_datasets_3(mock_hdx):
+    _ = get_filtered_datasets(
+        organization="",
+        dataset_filter="a-full-dataset-name",
+        query=None,
+    )
+
+    mock_hdx.assert_called_with("a-full-dataset-name")


### PR DESCRIPTION
## Purpose

Version for this PR: 2024.3.3

This PR does a refactoring which moves code from `cli.py` to `hdx_utilities.py`. It also publishes the package to PyPI which finalises the documentation issue 

#1 #9 #16 

## Major file changes
Functions moved from `cli.py` to `hdx_utilities.py`

## Minor file changes
Added a `publish.yaml` workflow. `pyproject.toml` updated to work and README.md modified.

## Versioning

`hdx-cli-toolkit` uses the CalVer versioning scheme with format YYYY.MM.Micro i.e. 2022.12.1 which is updated manually in `pyproject.toml`. The "Micro" component is simply an integer increased by 1 at each version, starting from 0.
- [x] Version updated in `pyproject.toml` and PR description
- [x] Update README.md and DEMO.md with any new CLI commands
