### PR TITLE
GH20 Fix get_organization_metadata bug

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Michael Rans
+Copyright (c) 2024 Ian Hopkinson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hdx_cli_toolkit"
-version = "2024.3.3"
+version = "2024.3.4"
 description = "HDX CLI tool kit for commandline interaction with HDX"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}

--- a/src/hdx_cli_toolkit/cli.py
+++ b/src/hdx_cli_toolkit/cli.py
@@ -253,7 +253,7 @@ def get_organization_metadata(organization: str, hdx_site: str = "stage", verbos
             print(json.dumps(filtered_organization.data, indent=2), flush=True)
         else:
             print(
-                f"{organization['name']:<50.50}: {filtered_organization['id']}",
+                f"{filtered_organization['name']:<50.50}: {filtered_organization['id']}",
                 flush=True,
             )
 

--- a/tests/cli_shell_test.sh
+++ b/tests/cli_shell_test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+echo "Executing read only hdx-toolkit commands"
+hdx-toolkit --help
+hdx-toolkit list --help
+hdx-toolkit configuration
+hdx-toolkit list --organization=healthsites --dataset_filter=*al*-healthsites --hdx_site=stage --key=private --value=True
+hdx-toolkit list --organization=international-organization-for-migration --key=data_update_frequency,dataset_date --output_path=list-test-1.csv
+rm list-test-1.csv
+hdx-toolkit list --query=archived:true --key=owner_org --output_path=list-test-2.csv
+rm list-test-2.csv
+hdx-toolkit get_organization_metadata --organization=zurich
+hdx-toolkit get_organization_metadata --organization=eth-zurich-weather-and-climate-risks --verbose
+hdx-toolkit get_user_metadata --user=hopkinson
+hdx-toolkit get_user_metadata --user=hopkinson --verbose
+hdx-toolkit print --dataset_filter=climada-litpop-dataset
+hdx-toolkit print --dataset_filter=wfp-food-prices-for-nigeria --with_extras
+echo "Reached end successfully"


### PR DESCRIPTION
## Purpose

This is a quick fix for a bug introduced into `get_organization_metadata` in the refactor. It includes the addition of a shell script containing all of the 

Version for this PR: 2024.3.4

#20 


## Major file changes
None

## Minor file changes
Added a shell test file. A very small change in `cli.py`

## Versioning

`hdx-cli-toolkit` uses the CalVer versioning scheme with format YYYY.MM.Micro i.e. 2022.12.1 which is updated manually in `pyproject.toml`. The "Micro" component is simply an integer increased by 1 at each version, starting from 0.
- [x] Version updated in `pyproject.toml` and PR description
- [x] Update README.md and DEMO.md with any new CLI commands
