### PR TITLE
GH6 Output the approved tag list

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -27,6 +27,13 @@ Understanding the `Configuration` used by `hdx-python-api` can be challenging fo
 hdx-toolkit configuration
 ```
 
+The `configuration` command can also be used to list the approved dataset tags using:
+
+`hdx-toolkit configuration --approved_tag_list`
+
+This produces an output containing only the tags with no boilerplate, it can be piped into a file
+or `grep` to find particular tags.
+
 The `list` and `update` commands are designed to be used together, using `list` to check what a potentially destructive `update` will do, and then simply repeating the same commandline with `list` replaced with `update`. This commandline selects a single dataset, `mali-healthsites`:
 
 ```shell
@@ -179,6 +186,7 @@ Potential new features can be found in the [GitHub issue tracker](https://github
 hdx-toolkit --help
 hdx-toolkit list --help
 hdx-toolkit configuration
+hdx-toolkit configuration --approved_tag_list
 hdx-toolkit list --organization=healthsites --dataset_filter=*al*-healthsites --hdx_site=stage --key=private --value=True
 hdx-toolkit list --organization=international-organization-for-migration --key=data_update_frequency,dataset_date --output_path=2024-02-05-iom-dtm.csv
 hdx-toolkit list --query=archived:true --key=owner_org --output_path=2024-02-08-archived-datasets.csv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hdx_cli_toolkit"
-version = "2024.4.2"
+version = "2024.4.3"
 description = "HDX CLI tool kit for commandline interaction with HDX"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}

--- a/src/hdx_cli_toolkit/cli.py
+++ b/src/hdx_cli_toolkit/cli.py
@@ -32,6 +32,7 @@ from hdx_cli_toolkit.hdx_utilities import (
     get_filtered_datasets,
     decorate_dataset_with_extras,
     download_hdx_datasets,
+    get_approved_tag_list,
 )
 
 
@@ -294,8 +295,19 @@ def get_user_metadata(user: str, hdx_site: str = "stage", verbose: bool = False)
 
 
 @hdx_toolkit.command(name="configuration")
-def show_configuration():
+@click.option(
+    "--approved_tag_list",
+    is_flag=True,
+    default=False,
+    help="if present then print the list of approved tags",
+)
+def show_configuration(approved_tag_list: bool = False):
     """Print configuration information to terminal"""
+    if approved_tag_list:
+        approved_tags = get_approved_tag_list()
+        for approved_tag in approved_tags:
+            print(approved_tag, flush=True)
+        return
     print_banner("configuration")
     # Check files
     user_hdx_config_yaml = os.path.join(os.path.expanduser("~"), ".hdx_configuration.yaml")

--- a/tests/cli_shell_test.sh
+++ b/tests/cli_shell_test.sh
@@ -3,6 +3,7 @@ echo "Executing read only hdx-toolkit commands"
 hdx-toolkit --help
 hdx-toolkit list --help
 hdx-toolkit configuration
+hdx-toolkit configuration --approved_tag_list
 hdx-toolkit list --organization=healthsites --dataset_filter=*al*-healthsites --hdx_site=stage --key=private --value=True
 hdx-toolkit list --organization=international-organization-for-migration --key=data_update_frequency,dataset_date --output_path=list-test-1.csv
 rm list-test-1.csv

--- a/tests/test_hdx_utilities_integration.py
+++ b/tests/test_hdx_utilities_integration.py
@@ -18,6 +18,7 @@ from hdx_cli_toolkit.hdx_utilities import (
     update_values_in_hdx,
     add_showcase,
     add_quickcharts,
+    get_approved_tag_list,
 )
 
 from hdx_cli_toolkit.utilities import make_conversion_func
@@ -200,3 +201,8 @@ def test_add_quickcharts():
 
     assert len(quickchart_dicts) == 2
     assert quickchart_dicts[1]["title"] == "Quick Charts"
+
+
+def test_get_approved_tag_list():
+    approved_tags = get_approved_tag_list()
+    assert len(approved_tags) == 140


### PR DESCRIPTION
## Purpose

Version for this PR: 2024.4.3

#6 


## Major file changes
A new function is added to `hdx_utilities.py` and an option added to the configuration command in `cli.py`

## Minor file changes
Tests and documentation

## Versioning

`hdx-cli-toolkit` uses the CalVer versioning scheme with format YYYY.MM.Micro i.e. 2022.12.1 which is updated manually in `pyproject.toml`. The "Micro" component is simply an integer increased by 1 at each version, starting from 0.
- [x] Version updated in `pyproject.toml` and PR description
- [x] Update README.md and DEMO.md with any new CLI commands
