### PR TITLE
GH28 Fixing the error handling 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hdx_cli_toolkit"
-version = "2024.4.4"
+version = "2024.4.5"
 description = "HDX CLI tool kit for commandline interaction with HDX"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}

--- a/src/hdx_cli_toolkit/cli.py
+++ b/src/hdx_cli_toolkit/cli.py
@@ -192,6 +192,8 @@ def update(
             return
 
         print(f"Updating key '{key}' with value '{value}'")
+        conversion_func = None
+        type_name = ""
         for filtered_dataset in filtered_datasets:
             try:
                 conversion_func, type_name = make_conversion_func(filtered_dataset[key])

--- a/src/hdx_cli_toolkit/hdx_utilities.py
+++ b/src/hdx_cli_toolkit/hdx_utilities.py
@@ -12,6 +12,7 @@ import urllib3
 
 from pathlib import Path
 
+import ckanapi
 import click
 import urllib3.util
 import yaml
@@ -39,7 +40,7 @@ def hdx_error_handler(f):
     def inner(*args, **kwargs):
         try:
             return f(*args, **kwargs)
-        except HDXError:
+        except (HDXError, ckanapi.errors.ValidationError):
             traceback_message = traceback.format_exc()
             message = parse_hdxerror_traceback(traceback_message)
             if message != "unknown":

--- a/src/hdx_cli_toolkit/hdx_utilities.py
+++ b/src/hdx_cli_toolkit/hdx_utilities.py
@@ -40,29 +40,27 @@ def hdx_error_handler(f):
         try:
             return f(*args, **kwargs)
         except HDXError:
-            message = parse_hdxerror_traceback(traceback.format_exc())
-            if message == "unknown":
+            traceback_message = traceback.format_exc()
+            message = parse_hdxerror_traceback(traceback_message)
+            if message != "unknown":
                 click.secho(
                     f"Could not perform operation on HDX because of an `{message}`",
                     fg="red",
                     color=True,
                 )
             else:
-                print(traceback.format_exc)
+                print(traceback_message, flush=True)
 
     return inner
 
 
 def parse_hdxerror_traceback(traceback_message: str):
     message = "unknown"
-    if "Authorization Error" in traceback.format_exc():
+    if "Authorization Error" in traceback_message:
         message = "Authorization Error"
-    elif (
-        "{'extras': [{}, {'key': ['There is a schema field with the same name']}]"
-        in traceback.format_exc()
-    ):
+    elif "extras" in traceback_message:
         message = "Extras Key Error"
-    elif "KeyError: 'resources'" in traceback.format_exc():
+    elif "KeyError: 'resources'" in traceback_message:
         message = "No Resources Error"
 
     return message

--- a/tests/test_hdx_utilities_integration.py
+++ b/tests/test_hdx_utilities_integration.py
@@ -215,3 +215,27 @@ def test_update_values_in_hdx_from_file():
     update_values_in_hdx_from_file(HDX_SITE, update_file_path)
     dataset = Dataset.read_from_hdx(DATASET_NAME)
     assert dataset["caveats"] == "Second value from_file"
+
+    redo_file_path = os.path.join(
+        os.path.dirname(__file__), "fixtures", "update-from-file-redo.csv"
+    )
+    assert os.path.exists(redo_file_path)
+    if os.path.exists(redo_file_path):
+        os.remove(redo_file_path)
+
+
+def test_error_handling(capfd):
+    dataset = Dataset.read_from_hdx(DATASET_NAME)
+    key = "extras"
+    value = "Extras key is illegal"
+    conversion_func, _ = make_conversion_func(value)
+    n_changed, n_failures, output_rows = update_values_in_hdx(
+        [dataset], key, value, conversion_func, hdx_site=HDX_SITE
+    )
+
+    assert n_changed == 0
+    assert n_failures == 1
+    assert len(output_rows) == 1
+    output, _ = capfd.readouterr()
+
+    assert "Could not update hdx_cli_toolkit_test on 'stage' - Extras Key Error" in output


### PR DESCRIPTION
## Purpose

Version for this PR: 2024.4.5

This is a bug fix release, some other work highlighted that the error handler was not working correctly - as detailed in #28 - essentially a refactoring meant that error messages were only printed if they weren't recognised.  


## Major file changes
The major changes are in the error handling functions in `hdx_utilities.py`, a test is added in `test_hdx_utilities_integration.py`.

## Minor file changes
There are a couple of very minor bug fixes, tidying up a file generated during testing and making the count of changed datasets is correct.

## Versioning

`hdx-cli-toolkit` uses the CalVer versioning scheme with format YYYY.MM.Micro i.e. 2022.12.1 which is updated manually in `pyproject.toml`. The "Micro" component is simply an integer increased by 1 at each version, starting from 0.
- [x] Version updated in `pyproject.toml` and PR description
- [x] Update README.md and DEMO.md with any new CLI commands
