### PR TITLE
GH31/HDX-9932 Productionise remove_extras_keys

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -212,5 +212,6 @@ hdx-toolkit print --dataset_filter=wfp-food-prices-for-nigeria --with_extras
 hdx-toolkit quickcharts --dataset_filter=climada-flood-dataset --hdx_site=stage --resource_name=admin1-summaries-flood.csv --hdx_hxl_preview_file_path=quickchart-flood.json
 hdx-toolkit showcase --showcase_name=climada-litpop-showcase --hdx_site=stage --attributes_file_path=attributes.csv
 hdx-toolkit update_resource --dataset_name=hdx_cli_toolkit_test --resource_name="test_resource_1" --hdx_site=stage --resource_file_path=test-2.csv --live
- hdx-toolkit download --dataset=bangladesh-bgd-attacks-on-protection --hdx_site=stage
+hdx-toolkit download --dataset=bangladesh-bgd-attacks-on-protection --hdx_site=stage
+hdx-toolkit remove_extras_key --organization=healthsites --dataset_filter=*al*-healthsites --hdx_site=stage --output_path=temp.csv
 ```

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Commands:
   list                       List datasets in HDX
   print                      Print datasets in HDX to the terminal
   quickcharts                Upload QuickChart JSON description to HDX
+  remove_extras_key          Remove extras key from a dataset
   showcase                   Upload showcase to HDX
   update                     Update datasets in HDX
   update_resource            Update a resource in HDX

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hdx_cli_toolkit"
-version = "2024.4.4"
+version = "2024.6.2"
 description = "HDX CLI tool kit for commandline interaction with HDX"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}

--- a/src/hdx_cli_toolkit/cli.py
+++ b/src/hdx_cli_toolkit/cli.py
@@ -586,10 +586,25 @@ def download(
 
 @hdx_toolkit.command(name="remove_extras_key")
 @click.option(
-    "--dataset_name",
+    "--organization",
+    is_flag=False,
+    default="",
+    help="an organization name",
+)
+@click.option(
+    "--dataset_filter",
     is_flag=False,
     default="*",
-    help="name of the dataset to update",
+    help="a dataset name or pattern on which to filter list",
+)
+@click.option(
+    "--query",
+    is_flag=False,
+    default=None,
+    help=(
+        "a dataset query string to pass to CKAN, "
+        "organization and dataset_filter are ignored if it is provided"
+    ),
 )
 @click.option(
     "--hdx_site",
@@ -597,7 +612,59 @@ def download(
     default="stage",
     help="an hdx_site value {stage|prod}",
 )
-def remove_extras_key(dataset_name: str = None, hdx_site: str = "stage"):
+@click.option(
+    "--verbose",
+    is_flag=True,
+    default=False,
+    help="if true show all user metadata",
+)
+@click.option(
+    "--output_path",
+    is_flag=False,
+    default=None,
+    help="A file path to export data from list to CSV",
+)
+def remove_extras_key(
+    organization: str = "",
+    dataset_filter: str = "*",
+    query: str = None,
+    hdx_site: str = "stage",
+    output_path: str = None,
+    verbose: bool = False,
+):
     """Remove extras key from a dataset"""
     print_banner("remove_extras_key")
-    remove_extras_key_from_dataset(dataset_name, hdx_site)
+    filtered_datasets = get_filtered_datasets(
+        organization=organization,
+        dataset_filter=dataset_filter,
+        hdx_site=hdx_site,
+        query=query,
+        verbose=False,
+    )
+    print(
+        (
+            f"Removing 'extras' key from datasets on '{hdx_site}' for datasets matching "
+            f"the filter organization='{organization}' and dataset_filter='{dataset_filter}'.\n"
+            f"Found {len(filtered_datasets)} to process."
+        ),
+        flush=True,
+    )
+    print(
+        f"{'dataset_name':<70.70}{'had_extras':<20.20}{'removed_--outsuccessfully':<20.20}",
+        flush=True,
+    )
+    output_rows = []
+    for dataset in filtered_datasets:
+        status_row = remove_extras_key_from_dataset(dataset, hdx_site, verbose=verbose)
+        print(
+            f"{status_row['dataset_name']:<70}"
+            f"{str(status_row['had_extras']):<20}"
+            f"{str(status_row['removed_successfully']):<20}",
+            flush=True,
+        )
+        output_rows.append(status_row)
+    if output_path is not None:
+        print("Writing results to file", flush=True)
+        output_path = make_path_unique(output_path)
+        status = write_dictionary(output_path, output_rows, append=False)
+        print(status, flush=True)

--- a/src/hdx_cli_toolkit/cli.py
+++ b/src/hdx_cli_toolkit/cli.py
@@ -35,6 +35,7 @@ from hdx_cli_toolkit.hdx_utilities import (
     decorate_dataset_with_extras,
     download_hdx_datasets,
     get_approved_tag_list,
+    remove_extras_key_from_dataset,
 )
 
 
@@ -581,3 +582,22 @@ def download(
     print("The following files were downloaded:", flush=True)
     for download_path in download_paths:
         print(download_path, flush=True)
+
+
+@hdx_toolkit.command(name="remove_extras_key")
+@click.option(
+    "--dataset_name",
+    is_flag=False,
+    default="*",
+    help="name of the dataset to update",
+)
+@click.option(
+    "--hdx_site",
+    is_flag=False,
+    default="stage",
+    help="an hdx_site value {stage|prod}",
+)
+def remove_extras_key(dataset_name: str = None, hdx_site: str = "stage"):
+    """Remove extras key from a dataset"""
+    print_banner("remove_extras_key")
+    remove_extras_key_from_dataset(dataset_name, hdx_site)

--- a/src/hdx_cli_toolkit/cli.py
+++ b/src/hdx_cli_toolkit/cli.py
@@ -34,7 +34,7 @@ from hdx_cli_toolkit.hdx_utilities import (
     get_filtered_datasets,
     decorate_dataset_with_extras,
     download_hdx_datasets,
-    get_appro
+    get_approved_tag_list,
     remove_extras_key_from_dataset,
     check_api_key,
 )

--- a/src/hdx_cli_toolkit/hdx_utilities.py
+++ b/src/hdx_cli_toolkit/hdx_utilities.py
@@ -593,6 +593,7 @@ def remove_extras_key_from_dataset(
 
     return output_row
 
+
 def check_api_key(organization: str = "hdx", hdx_sites: str = None) -> list[str]:
     if hdx_sites is None:
         hdx_sites = ["stage", "prod"]

--- a/src/hdx_cli_toolkit/utilities.py
+++ b/src/hdx_cli_toolkit/utilities.py
@@ -5,6 +5,7 @@ import csv
 import dataclasses
 import datetime
 import json
+import math
 import os
 
 from collections.abc import Callable
@@ -294,3 +295,43 @@ def make_path_unique(input_path: str) -> str:
         counter += 1
 
     return unique_path
+
+
+def print_dictionary_comparison(
+    dict1: dict,
+    dict2: dict,
+    name1: str = "first_dict",
+    name2: str = "second_dict",
+    differences: bool = False,
+) -> None:
+    unified_keys = set(list(dict1.keys()))
+    unified_keys.update(list(dict2.keys()))
+    total_width = 100
+    key_width = max(len(x) for x in unified_keys) + 1
+
+    dict_one_width = math.floor((total_width - 4 - key_width) / 2)
+    dict_two_width = dict_one_width
+    total_width = key_width + dict_one_width + dict_two_width + 4
+
+    print("\n", flush=True)
+    print("-" * total_width, flush=True)
+    print(
+        f"|{'key':<{key_width}}|{name1:<{dict_one_width}}|{name2:<{dict_two_width}}|",
+        flush=True,
+    )
+    print("-" * total_width, flush=True)
+
+    for key in unified_keys:
+        value1 = dict1.get(key, "Not present")
+        value2 = dict2.get(key, "Not present")
+
+        if differences and value1 == value2:
+            continue
+        else:
+            print(
+                f"|{key:<{key_width}}"
+                f"|{str(value1):<{dict_one_width}.{dict_one_width}}"
+                f"|{str(value2):<{dict_two_width}.{dict_two_width}}|",
+                flush=True,
+            )
+    print("-" * total_width, flush=True)


### PR DESCRIPTION
## Purpose

Version for this PR: 2024.6.2

This PR productionises the `remove_extras_key` command so that it aligns with the form of the `list` and `update` in terms of methods for providing the datasets to be addressed and also outputs results to an output_path.

This is rather tricky to test since the `extras` key is "illegal" meaning you can't create a dataset with it.
#31 


## Major file changes
Updates in `cli.py` and `hdx_utilities.py`

## Minor file changes
The `DEMO.MD` and `README.MD` files get updated. As does the version in `pyproject.toml`. We add a new utility for comparing dictionaries to `utilities.py`.

## Versioning

`hdx-cli-toolkit` uses the CalVer versioning scheme with format YYYY.MM.Micro i.e. 2022.12.1 which is updated manually in `pyproject.toml`. The "Micro" component is simply an integer increased by 1 at each version, starting from 0.
- [x] Version updated in `pyproject.toml` and PR description
- [x] Update README.md and DEMO.md with any new CLI commands
