### PR TITLE
Update USERGUIDE.md

### DIFF
--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -98,7 +98,7 @@ which selects 29 datasets matching the filter `*la*`, or
 ```shell
 hdx-toolkit list --organization=healthsites --dataset_filter=* --hdx_site=stage --key=private --value=True
 ```
-which selects all the datasets of an organization. The `update` command can provide an output file listing the changes made which can subsequently be used in an `undo` operation:
+which selects all the datasets of an organization. Note that the filters acts on dataset names (used in URL), not the titles (shown in the HDX dataset page). The `update` command can provide an output file listing the changes made which can subsequently be used in an `undo` operation:
 ```shell
 hdx-toolkit update --organization=healthsites --dataset_filter=somalia-healthsites --hdx_site=stage --key=caveats --value="test entry" --output_path=2024-04-29-undo-test.csv
 ```

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -96,7 +96,7 @@ hdx-toolkit list --organization=healthsites --dataset_filter=*la* --hdx_site=sta
 
 which selects 29 datasets matching the filter `*la*`, or
 ```shell
-hdx-toolkit list --organization=healthsites--dataset_filter=* --hdx_site=stage --key=private --value=True
+hdx-toolkit list --organization=healthsites --dataset_filter=* --hdx_site=stage --key=private --value=True
 ```
 which selects all the datasets of an organization. The `update` command can provide an output file listing the changes made which can subsequently be used in an `undo` operation:
 ```shell


### PR DESCRIPTION
Just a space missing in one of the CLI examples.

## Purpose

Version for this PR: 202*.*.*

- [] [GitHub issue or issues if relevant](https://www.google.com)


## Major file changes
Describe major file changes in brief

## Minor file changes
Outline why other files have changed

## Versioning

`hdx-cli-toolkit` uses the CalVer versioning scheme with format YYYY.MM.Micro i.e. 2022.12.1 which is updated manually in `pyproject.toml`. The "Micro" component is simply an integer increased by 1 at each version, starting from 0.
- [] Version updated in `pyproject.toml` and PR description
- [] Update README.md and DEMO.md with any new CLI commands
