### PR TITLE
GH42 Add shape_info support and fix some small documentation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ hdx-cli-toolkit:
 
 The `hdx-toolkit` is built using the Python `click` library. Details of the currently implemented commands can be revealed by running `hdx-toolkit --help`, and details of the arguments for a command can be found using `hdx-toolkit [COMMAND] --help`
 
-A detailed guide can be found in the [USERGUIDE.md](USERGUIDE.md) file
+A detailed guide can be found in the [USERGUIDE.md](https://github.com/OCHA-DAP/hdx-cli-toolkit/blob/main/USERGUIDE.md) file
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Users may prefer to make a global, isolated installation using [pipx](https://py
 `hdx-cli-toolkit` uses the `hdx-python-api` library, this requires the following to be added to a file called `.hdx_configuration.yaml` in the user's home directory.
 
 ```
-hdx_key_stage: "[hdx_key from the staging HDX site]"
-hdx_key: "[hdx_key from the prod HDX site]"
+hdx_key_stage: "[an HDX API token from the staging HDX site]"
+hdx_key: "[an HDX API token from the prod HDX site]"
 ```
 
 A user agent (`hdx_cli_toolkit_*`) is specified in the `~/.useragents.yaml` file with the * replaced with the users initials.
@@ -77,7 +77,7 @@ This project uses a GitHub Action to run tests and linting. It requires the foll
 
 ```
 HDX_KEY - secret. Value: fake secret
-HDX_KEY_STAGE - secret. Value: a live API key for the stage server
+HDX_KEY_STAGE - secret. Value: a live API token for the stage server
 HDX_SITE - environment variable. Value: stage
 USER_AGENT - environment variable. Value: hdx_cli_toolkit_gha
 PREPREFIX - - environment variable. Value: [YOUR_organization]

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -177,7 +177,7 @@ It is possible to include resource, showcase and QuickChart (resource_view) meta
 hdx-toolkit print --dataset_filter=wfp-food-prices-for-nigeria --with_extras
 ```
 
-This adds resources under a `resources` key which includes a `quickcharts` key and showcases under a `showcases` key. These new keys mean that the output JSON cannot be created directly in HDX. The `fs_check_info` and `hxl_preview_config` keys which previously contained a JSON object serialised as a single string are expanded as dictionaries so that they are printed out in an easy to read format.
+This adds resources under a `resources` key which includes a `quickcharts` key and showcases under a `showcases` key. These new keys mean that the output JSON cannot be created directly in HDX. The `fs_check_info`, `shape_info` and `hxl_preview_config` keys which previously contained a JSON object serialised as a single string are expanded as dictionaries so that they are printed out in an easy to read format.
 
 ## Quick Charts
 
@@ -299,6 +299,7 @@ hdx-toolkit get_user_metadata --user=hopkinson
 hdx-toolkit get_user_metadata --user=hopkinson --verbose
 hdx-toolkit print --dataset_filter=climada-litpop-dataset
 hdx-toolkit print --dataset_filter=wfp-food-prices-for-nigeria --with_extras
+hdx-toolkit print --dataset_filter=geoboundaries-admin-boundaries-for-nepal --with_extras
 hdx-toolkit quickcharts --dataset_filter=climada-flood-dataset --hdx_site=stage --resource_name=admin1-summaries-flood.csv --hdx_hxl_preview_file_path=quickchart-flood.json
 hdx-toolkit showcase --showcase_name=climada-litpop-showcase --hdx_site=stage --attributes_file_path=attributes.csv
 hdx-toolkit update_resource --dataset_name=hdx_cli_toolkit_test --resource_name="test_resource_1" --hdx_site=stage --resource_file_path=test-2.csv --live

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -98,7 +98,7 @@ which selects 29 datasets matching the filter `*la*`, or
 ```shell
 hdx-toolkit list --organization=healthsites --dataset_filter=* --hdx_site=stage --key=private --value=True
 ```
-which selects all the datasets of an organization. The `update` command can provide an output file listing the changes made which can subsequently be used in an `undo` operation:
+which selects all the datasets of an organization. Note that the filters acts on dataset names (used in URL), not the titles (shown in the HDX dataset page). The `update` command can provide an output file listing the changes made which can subsequently be used in an `undo` operation:
 ```shell
 hdx-toolkit update --organization=healthsites --dataset_filter=somalia-healthsites --hdx_site=stage --key=caveats --value="test entry" --output_path=2024-04-29-undo-test.csv
 ```

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -31,8 +31,8 @@ Users may prefer to make a global, isolated installation using [pipx](https://py
 `hdx-cli-toolkit` uses the `hdx-python-api` library, this requires the following to be added to a file called `.hdx_configuration.yaml` in the user's home directory.
 
 ```
-hdx_key_stage: "[hdx_key from the staging HDX site]"
-hdx_key: "[hdx_key from the prod HDX site]"
+hdx_key_stage: "[an HDX API token from the staging HDX site]"
+hdx_key: "[an HDX API token from the prod HDX site]"
 ```
 
 A user agent (`hdx_cli_toolkit_*`) is specified in the `~/.useragents.yaml` file with the * replaced with the users initials.

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -96,7 +96,7 @@ hdx-toolkit list --organization=healthsites --dataset_filter=*la* --hdx_site=sta
 
 which selects 29 datasets matching the filter `*la*`, or
 ```shell
-hdx-toolkit list --organization=healthsites--dataset_filter=* --hdx_site=stage --key=private --value=True
+hdx-toolkit list --organization=healthsites --dataset_filter=* --hdx_site=stage --key=private --value=True
 ```
 which selects all the datasets of an organization. The `update` command can provide an output file listing the changes made which can subsequently be used in an `undo` operation:
 ```shell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hdx_cli_toolkit"
-version = "2024.8.2"
+version = "2024.12.1"
 description = "HDX CLI tool kit for commandline interaction with HDX"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}

--- a/src/hdx_cli_toolkit/cli.py
+++ b/src/hdx_cli_toolkit/cli.py
@@ -139,7 +139,7 @@ def list_datasets(
     )
     # Automate setting of with_extras
     with_extras = False
-    for extra_key in ["resources", "quickcharts", "showcases", "fs_check_info"]:
+    for extra_key in ["resources", "quickcharts", "showcases", "fs_check_info", "shape_info"]:
         if extra_key in key:
             with_extras = True
 

--- a/src/hdx_cli_toolkit/hdx_utilities.py
+++ b/src/hdx_cli_toolkit/hdx_utilities.py
@@ -310,9 +310,10 @@ def decorate_dataset_with_extras(
     dataset: Dataset, hdx_site: str = "stage", verbose: bool = False
 ) -> dict:
     """A function to add resource, quickcharts (resource_view) and showcases keys to a dataset
-    dictionary representation for the print command. fs_check_info, shape_info and hxl_preview_config are
-    converted from JSON objects serialised as single strings to dictionaries to make printed output
-    more readable. This decoration means that the dataset dictionary cannot be uploaded to HDX.
+    dictionary representation for the print command. fs_check_info, shape_info and
+    hxl_preview_config are converted from JSON objects serialised as single strings to
+    dictionaries to make printed output more readable. This decoration means that the dataset
+    dictionary cannot be uploaded to HDX.
 
     Arguments:
         dataset {Dataset} -- a Dataset object to process

--- a/src/hdx_cli_toolkit/hdx_utilities.py
+++ b/src/hdx_cli_toolkit/hdx_utilities.py
@@ -310,7 +310,7 @@ def decorate_dataset_with_extras(
     dataset: Dataset, hdx_site: str = "stage", verbose: bool = False
 ) -> dict:
     """A function to add resource, quickcharts (resource_view) and showcases keys to a dataset
-    dictionary representation for the print command. fs_check_info and hxl_preview_config are
+    dictionary representation for the print command. fs_check_info, shape_info and hxl_preview_config are
     converted from JSON objects serialised as single strings to dictionaries to make printed output
     more readable. This decoration means that the dataset dictionary cannot be uploaded to HDX.
 
@@ -328,6 +328,8 @@ def decorate_dataset_with_extras(
         resource_dict = resource.data
         if "fs_check_info" in resource_dict:
             resource_dict["fs_check_info"] = json.loads(resource_dict["fs_check_info"])
+        if "shape_info" in resource_dict:
+            resource_dict["shape_info"] = json.loads(resource_dict["shape_info"])
         dataset_quickcharts = ResourceView.get_all_for_resource(resource_dict["id"])
         resource_dict["quickcharts"] = []
         if dataset_quickcharts is not None:

--- a/tests/test_hdx_utilities_integration.py
+++ b/tests/test_hdx_utilities_integration.py
@@ -208,7 +208,7 @@ def test_add_quickcharts():
 
 def test_get_approved_tag_list():
     approved_tags = get_approved_tag_list()
-    assert len(approved_tags) == 140
+    assert len(approved_tags) == 141
 
 
 def test_update_values_in_hdx_from_file():


### PR DESCRIPTION
## Purpose

Version for this PR: 2024.12.1

Addresses the following issues:
#40 
#42
#43 
#44


## Major file changes
There are no major changes

## Minor file changes
Small changes to `README.md`, `USERGUIDE.md` and `hdx_utilities.py`

## Versioning

`hdx-cli-toolkit` uses the CalVer versioning scheme with format YYYY.MM.Micro i.e. 2022.12.1 which is updated manually in `pyproject.toml`. The "Micro" component is simply an integer increased by 1 at each version, starting from 0.
- [x] Version updated in `pyproject.toml` and PR description
- [x] Update README.md and DEMO.md with any new CLI commands
