### PR TITLE
GH48/50 Fix issues with None and providing an organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This toolkit provides a commandline interface to the [Humanitarian Data Exchange
   update_resource            Update a resource in HDX
 ```
 
-It is a thin wrapper to the [hdx-python-api](https://github.com/OCHA-DAP/hdx-python-api) library written by Mike Rans.
+In the most part it is a thin wrapper to the [hdx-python-api](https://github.com/OCHA-DAP/hdx-python-api) library written by Mike Rans.
 
 The library requires some configuration, described below, to authenticate to the HDX instance.
 
@@ -41,7 +41,10 @@ Users may prefer to make a global, isolated installation using [pipx](https://py
 ```
 hdx_key_stage: "[an HDX API token from the staging HDX site]"
 hdx_key: "[an HDX API token from the prod HDX site]"
+default_organization: "[your organization]"
 ```
+
+The `default_organization` is required for the `configuration` command and can be supplied using the `--organization=` commandline parament. If not defined it will default to `hdx`. 
 
 A user agent (`hdx_cli_toolkit_*`) is specified in the `~/.useragents.yaml` file with the * replaced with the users initials.
 ```

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -33,7 +33,10 @@ Users may prefer to make a global, isolated installation using [pipx](https://py
 ```
 hdx_key_stage: "[an HDX API token from the staging HDX site]"
 hdx_key: "[an HDX API token from the prod HDX site]"
+default_organization: "[your organization]"
 ```
+
+The `default_organization` is required for the `configuration` command and can be supplied using the `--organization=` commandline parament. If not defined it will default to `hdx`. 
 
 A user agent (`hdx_cli_toolkit_*`) is specified in the `~/.useragents.yaml` file with the * replaced with the users initials.
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hdx_cli_toolkit"
-version = "2024.12.1"
+version = "2025.1.1"
 description = "HDX CLI tool kit for commandline interaction with HDX"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}

--- a/src/hdx_cli_toolkit/cli.py
+++ b/src/hdx_cli_toolkit/cli.py
@@ -362,7 +362,7 @@ def get_user_metadata(user: str, hdx_site: str = "stage", verbose: bool = False)
 @click.option(
     "--organization",
     is_flag=False,
-    default="hdx",
+    default=None,
     help="an organization name to check API keys against",
 )
 def show_configuration(approved_tag_list: bool = False, organization: str = "hdx"):
@@ -393,7 +393,17 @@ def show_configuration(approved_tag_list: bool = False, organization: str = "hdx
                     key_part, secret_part = row.split(":")
                     secret_part = censor_secret(secret_part)
                     row = key_part + ': "' + secret_part
+                if row.startswith("default_organization") and organization is None:
+                    key_part, organization = row.split(":")
+                    organization = organization.strip().replace('"', "")
                 print(row, flush=True)
+        if organization is None:
+            print(
+                "No organization provided in commandline or "
+                "configuration file so defaulting to 'hdx'",
+                flush=True,
+            )
+            organization = "hdx"
     else:
         click.secho(
             f"No user configuration file at {user_hdx_config_yaml}. ",

--- a/src/hdx_cli_toolkit/cli.py
+++ b/src/hdx_cli_toolkit/cli.py
@@ -397,13 +397,6 @@ def show_configuration(approved_tag_list: bool = False, organization: Optional[s
                     key_part, organization = row.split(":")
                     organization = organization.strip().replace('"', "")
                 print(row, flush=True)
-        if organization is None:
-            print(
-                "No organization provided in commandline or "
-                "configuration file so defaulting to 'hdx'",
-                flush=True,
-            )
-            organization = "hdx"
     else:
         click.secho(
             f"No user configuration file at {user_hdx_config_yaml}. ",
@@ -417,6 +410,14 @@ def show_configuration(approved_tag_list: bool = False, organization: Optional[s
             'hdx_key: "[API Key obtained from '
             'https://data.humdata.org/user/[your username]]/api-tokens]"\n'
         )
+
+    if organization is None:
+        print(
+            "No organization provided in commandline or "
+            "configuration file so defaulting to 'hdx'",
+            flush=True,
+        )
+        organization = "hdx"
 
     user_agent_config_yaml = os.path.join(os.path.expanduser("~"), ".useragents.yaml")
     if os.path.exists(user_agent_config_yaml):

--- a/src/hdx_cli_toolkit/cli.py
+++ b/src/hdx_cli_toolkit/cli.py
@@ -365,7 +365,7 @@ def get_user_metadata(user: str, hdx_site: str = "stage", verbose: bool = False)
     default=None,
     help="an organization name to check API keys against",
 )
-def show_configuration(approved_tag_list: bool = False, organization: str = "hdx"):
+def show_configuration(approved_tag_list: bool = False, organization: Optional[str] = None):
     """Print configuration information to terminal"""
     if approved_tag_list:
         approved_tags = get_approved_tag_list()

--- a/src/hdx_cli_toolkit/hdx_utilities.py
+++ b/src/hdx_cli_toolkit/hdx_utilities.py
@@ -641,11 +641,13 @@ def check_api_key(organization: str = "hdx", hdx_sites: Optional[list[str]] = No
         )
         if result:
             statuses.append(
-                f"API key valid on '{hdx_site}' to create datasets for '{organization}'"
+                f"API key valid on '{hdx_site}' to create datasets for "
+                f"organization '{organization}'"
             )
         else:
             statuses.append(
-                f"API key not valid on '{hdx_site}' to create datasets for '{organization}'"
+                f"API key not valid on '{hdx_site}' to create datasets for "
+                f"organization '{organization}'"
             )
 
     return statuses

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -30,7 +30,7 @@ def test_configuration():
     expected_outputs = [
         "Values of relevant environment variables (used in absence of supplied values):",
         ' url: "https://stage.data-humdata-org.ahconu.org"',
-        "API key valid on 'stage' to create datasets for 'hdx'",
+        "API key valid on 'stage' to create datasets for organization 'hdx'",
     ]
 
     cli_test_template(command, cli_arguments, expected_outputs, forbidden_output="")


### PR DESCRIPTION
## Purpose

Version for this PR: 2025.1.1

This PR has some minor fixes. None is checked for when doing `get_filtered_datasets` and the variable names in this function are tidied up (rather than using `organization` in three different ways!)

Users can now supply a `default_organization` in the config file.

Relevant issues:
- #48 
- #50 

## Major file changes
Describe major file changes in brief

## Minor file changes
Outline why other files have changed

## Versioning

`hdx-cli-toolkit` uses the CalVer versioning scheme with format YYYY.MM.Micro i.e. 2022.12.1 which is updated manually in `pyproject.toml`. The "Micro" component is simply an integer increased by 1 at each version, starting from 0.
- [x] Version updated in `pyproject.toml` and PR description
- [x] Update README.md and DEMO.md with any new CLI commands
