### PR TITLE
HXL retirement 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This toolkit provides a commandline interface to the [Humanitarian Data Exchange
   get_user_metadata          Get user id and other metadata
   list                       List datasets in HDX
   print                      Print datasets in HDX to the terminal
-  quickcharts                Upload QuickChart JSON description to HDX
   remove_extras_key          Remove extras key from a dataset
   scan                       Scan all of HDX and perform an action
   showcase                   Upload showcase to HDX
@@ -59,6 +58,12 @@ hdx-cli-toolkit:
 The `hdx-toolkit` is built using the Python `click` library. Details of the currently implemented commands can be revealed by running `hdx-toolkit --help`, and details of the arguments for a command can be found using `hdx-toolkit [COMMAND] --help`
 
 A detailed guide can be found in the [USERGUIDE.md](https://github.com/OCHA-DAP/hdx-cli-toolkit/blob/main/USERGUIDE.md) file
+
+## Changelog
+
+Entries commence with 2026.2.1
+
+**2026.2.1** - this release removes the `quickcharts` command since HXL is to be removed from HDX and quickcharts depends on this. There are also a couple of removals of `hxl_update=False` from calls which should make no difference to the end user.
 
 ## Maintenance 
 

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -12,7 +12,6 @@ This toolkit provides a commandline interface to the [Humanitarian Data Exchange
   get_user_metadata          Get user id and other metadata
   list                       List datasets in HDX
   print                      Print datasets in HDX to the terminal
-  quickcharts                Upload QuickChart JSON description to HDX
   remove_extras_key          Remove extras key from a dataset
   scan                       Scan all of HDX and perform an action
   showcase                   Upload showcase to HDX
@@ -124,7 +123,7 @@ The `list` command can output multiple comma separated keys to a table, and also
 hdx-toolkit list --organization=international-organization-for-migration --key=data_update_frequency,dataset_date --output_path=2024-02-05-iom-dtm.csv
 ```
 
-`list` can also output the value of nested keys such as `organization.name` or lists of values such as `tags.name` or `groups.name`. The displaying attributes from `resources`, `quickcharts`, `showcases`, `fs_check_info` and `shape_info` forces multiple queries to HDX per dataset and can be slow, therefore it should only be used if necessary and only for small numbers of datasets at a time. An example of this is as follows:
+`list` can also output the value of nested keys such as `organization.name` or lists of values such as `tags.name` or `groups.name`. The displaying attributes from `resources`, `showcases`, `fs_check_info` and `shape_info` forces multiple queries to HDX per dataset and can be slow, therefore it should only be used if necessary and only for small numbers of datasets at a time. An example of this is as follows:
 
 ```shell
 hdx-toolkit list --organization=healthsites --dataset_filter=gibraltar-healthsites --hdx_site=stage --key=resources.name --value=True
@@ -181,17 +180,7 @@ It is possible to include resource, showcase and QuickChart (resource_view) meta
 hdx-toolkit print --dataset_filter=wfp-food-prices-for-nigeria --with_extras
 ```
 
-This adds resources under a `resources` key which includes a `quickcharts` key and showcases under a `showcases` key. These new keys mean that the output JSON cannot be created directly in HDX. The `fs_check_info`, `shape_info` and `hxl_preview_config` keys which previously contained a JSON object serialised as a single string are expanded as dictionaries so that they are printed out in an easy to read format.
-
-## Quick Charts
-
-A Quick Chart can be uploaded from a JSON file using a commandline like where the `dataset_filter` specifies a single dataset and the `resource_name` specifies the resource to which the Quick Chart is attached:
-
-```
- hdx-toolkit quickcharts --dataset_filter=climada-flood-dataset --hdx_site=stage --resource_name=admin1-summaries-flood.csv --hdx_hxl_preview_file_path=quickchart-flood.json
-```
-
-The `hdx_hxl_preview_file_path` points to a JSON format file with the key `hxl_preview_config` which contains the Quick Chart definition. This file is converted to a single string via a temporary yaml file so should be easily readable. Quick Chart recipe documentation can be found [here](https://github.com/OCHA-DAP/hxl-recipes?tab=readme-ov-file). There is an example file in the `hdx-cli-toolkit` [repo](https://github.com/OCHA-DAP/hdx-cli-toolkit/blob/main/tests/fixtures/quickchart-flood.json).
+This adds resources under a `resources` key which includes showcases under a `showcases` key. These new keys mean that the output JSON cannot be created directly in HDX. The `fs_check_info`, and `shape_info` keys which previously contained a JSON object serialised as a single string are expanded as dictionaries so that they are printed out in an easy to read format.
 
 ## Showcases
 
@@ -316,7 +305,6 @@ hdx-toolkit get_user_metadata --user=hopkinson --verbose
 hdx-toolkit print --dataset_filter=climada-litpop-dataset
 hdx-toolkit print --dataset_filter=wfp-food-prices-for-nigeria --with_extras
 hdx-toolkit print --dataset_filter=geoboundaries-admin-boundaries-for-nepal --with_extras
-hdx-toolkit quickcharts --dataset_filter=climada-flood-dataset --hdx_site=stage --resource_name=admin1-summaries-flood.csv --hdx_hxl_preview_file_path=quickchart-flood.json
 hdx-toolkit showcase --showcase_name=climada-litpop-showcase --hdx_site=stage --attributes_file_path=attributes.csv
 hdx-toolkit update_resource --dataset_name=hdx_cli_toolkit_test --resource_name="test_resource_1" --hdx_site=stage --resource_file_path=test-2.csv --live
 hdx-toolkit download --dataset=bangladesh-bgd-attacks-on-protection --hdx_site=stage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 
 dependencies = [
-  "hdx-python-api==6.3.1",
+  "hdx-python-api",
   "hdx-python-country",
   "ckanapi",
   "libhxl==5.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hdx_cli_toolkit"
-version = "2025.8.1"
+version = "2026.2.1"
 description = "HDX CLI tool kit for commandline interaction with HDX"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}

--- a/src/hdx_cli_toolkit/cli.py
+++ b/src/hdx_cli_toolkit/cli.py
@@ -29,7 +29,6 @@ from hdx_cli_toolkit.utilities import (
 
 from hdx_cli_toolkit.hdx_utilities import (
     add_showcase,
-    add_quickcharts,
     get_organizations_from_hdx,
     get_users_from_hdx,
     update_values_in_hdx,
@@ -474,51 +473,6 @@ def show_configuration(approved_tag_list: bool = False, organization: Optional[s
             if "API key not valid" in status:
                 color = "red"
             click.secho(f"{status}", fg=color, color=True)
-
-
-@hdx_toolkit.command(name="quickcharts")
-@click.option(
-    "--dataset_filter",
-    is_flag=False,
-    default="*",
-    help="a dataset name",
-)
-@click.option(
-    "--hdx_site",
-    is_flag=False,
-    default="stage",
-    help="an hdx_site value {stage|prod}",
-)
-@click.option(
-    "--resource_name",
-    is_flag=False,
-    default="stage",
-    help="name of resource to which the QuickCharts are attached",
-)
-@click.option(
-    "--hdx_hxl_preview_file_path",
-    is_flag=False,
-    default="stage",
-    help="name of resource to which the QuickCharts are attached",
-)
-def quickcharts(
-    dataset_filter: str = "",
-    hdx_site: str = "stage",
-    resource_name: str = "",
-    hdx_hxl_preview_file_path: str = "",
-):
-    """Upload QuickChart JSON description to HDX"""
-    print_banner("quickcharts")
-    print(
-        f"Adding Quick Chart defined at '{hdx_hxl_preview_file_path}' to dataset "
-        f"'{dataset_filter}', resource '{resource_name}'"
-    )
-    t0 = time.time()
-    status = add_quickcharts(dataset_filter, hdx_site, resource_name, hdx_hxl_preview_file_path)
-
-    print(status, flush=True)
-
-    print(f"Quick Chart update took {time.time() - t0:.2f} seconds")
 
 
 @hdx_toolkit.command(name="showcase")

--- a/src/hdx_cli_toolkit/hdx_utilities.py
+++ b/src/hdx_cli_toolkit/hdx_utilities.py
@@ -324,6 +324,9 @@ def decorate_dataset_with_extras(
     dictionaries to make printed output more readable. This decoration means that the dataset
     dictionary cannot be uploaded to HDX.
 
+    `hxl_preview_config` and `quickcharts` are to be removed from HDX but this function handles
+    their absence.
+
     Arguments:
         dataset {Dataset} -- a Dataset object to process
 
@@ -479,44 +482,6 @@ def update_resource_in_hdx(
 
     statuses.append("No '--live' flag supplied so no update to HDX made, otherwise successful")
     return statuses
-
-
-@hdx_error_handler
-def add_quickcharts(dataset_name, hdx_site, resource_name, hdx_hxl_preview_file_path):
-    configure_hdx_connection(hdx_site=hdx_site)
-    status = "Successful"
-
-    # read the json file
-    with open(hdx_hxl_preview_file_path, "r", encoding="utf-8") as json_file:
-        recipe = json.load(json_file)
-    # extract appropriate keys
-    processed_recipe = {
-        "description": "",
-        "title": "Quick Charts",
-        "view_type": "hdx_hxl_preview",
-        "hxl_preview_config": "",
-    }
-
-    # convert the configuration to a string
-    stringified_config = json.dumps(
-        recipe["hxl_preview_config"], indent=None, separators=(",", ":")
-    )
-    processed_recipe["hxl_preview_config"] = stringified_config
-    # write out yaml to a temp file
-    temp_yaml_path = f"{hdx_hxl_preview_file_path}.temp.yaml"
-    with open(temp_yaml_path, "w", encoding="utf-8") as yaml_file:
-        yaml.dump(processed_recipe, yaml_file)
-
-    dataset = Dataset.read_from_hdx(dataset_name)
-    if dataset is not None:
-        dataset.generate_quickcharts(resource=resource_name, path=temp_yaml_path)
-        dataset.update_in_hdx(update_resources=False)
-
-    # delete the temp file
-    if os.path.exists(temp_yaml_path):
-        os.remove(temp_yaml_path)
-
-    return status
 
 
 @hdx_error_handler

--- a/src/hdx_cli_toolkit/hdx_utilities.py
+++ b/src/hdx_cli_toolkit/hdx_utilities.py
@@ -263,7 +263,6 @@ def update_values_in_hdx(
                 dataset.data.pop("extras")
             dataset.update_in_hdx(
                 update_resources=False,
-                hxl_update=False,
                 operation="patch",
                 batch_mode="KEEP_OLD",
                 skip_validation=True,
@@ -511,7 +510,7 @@ def add_quickcharts(dataset_name, hdx_site, resource_name, hdx_hxl_preview_file_
     dataset = Dataset.read_from_hdx(dataset_name)
     if dataset is not None:
         dataset.generate_quickcharts(resource=resource_name, path=temp_yaml_path)
-        dataset.update_in_hdx(update_resources=False, hxl_update=False)
+        dataset.update_in_hdx(update_resources=False)
 
     # delete the temp file
     if os.path.exists(temp_yaml_path):
@@ -606,7 +605,7 @@ def remove_extras_key_from_dataset(
     if "extras" in original_dataset.data:
         output_row["had_extras"] = True
         original_dataset.data.pop("extras")
-        original_dataset.create_in_hdx(hxl_update=False, keys_to_delete=["extras"])
+        original_dataset.create_in_hdx(keys_to_delete=["extras"])
     else:
         # print(f"Extras key not found in {dataset_name} on {hdx_site}", flush=True)
         return output_row

--- a/tests/test_hdx_utilities_integration.py
+++ b/tests/test_hdx_utilities_integration.py
@@ -60,7 +60,7 @@ def setup_and_teardown_dataset_in_hdx():
 
     dataset.add_update_resource(resource)
 
-    dataset.create_in_hdx(hxl_update=False, updated_by_script="hdx_cli_toolkit_ignore")
+    dataset.create_in_hdx(updated_by_script="hdx_cli_toolkit_ignore")
 
     assert Dataset.read_from_hdx(DATASET_NAME) is not None
     # This is pytest teardown

--- a/tests/test_hdx_utilities_integration.py
+++ b/tests/test_hdx_utilities_integration.py
@@ -17,7 +17,6 @@ from hdx_cli_toolkit.hdx_utilities import (
     configure_hdx_connection,
     update_values_in_hdx,
     add_showcase,
-    add_quickcharts,
     get_approved_tag_list,
     update_values_in_hdx_from_file,
     get_hdx_url_and_key,
@@ -167,43 +166,6 @@ def test_add_showcase():
 
     assert len(showcases) == 1
     assert showcases[0]["title"] == "CLIMADA LitPop Methodology Documentation"
-
-
-def test_add_quickcharts():
-    resource_name = "admin1-summaries-flood.csv"
-    new_resource_file_path = os.path.join(os.path.dirname(__file__), "fixtures", resource_name)
-    _ = update_resource_in_hdx(
-        DATASET_NAME, resource_name, HDX_SITE, new_resource_file_path, live=True
-    )
-
-    hdx_hxl_preview_file_path = os.path.join(
-        os.path.dirname(__file__), "fixtures", "quickchart-flood.json"
-    )
-
-    status = add_quickcharts(DATASET_NAME, HDX_SITE, resource_name, hdx_hxl_preview_file_path)
-
-    assert status == "Successful"
-
-    dataset = Dataset.read_from_hdx(DATASET_NAME)
-    resources = dataset.get_resources()
-
-    quickchart_dicts = []
-    for resource in resources:
-        resource_dict = resource.data
-        if resource_dict["name"] != resource_name:
-            continue
-        dataset_quickcharts = ResourceView.get_all_for_resource(resource_dict["id"])
-        if dataset_quickcharts is not None:
-            for quickchart in dataset_quickcharts:
-                quickchart_dict = quickchart.data
-                if "hxl_preview_config" in quickchart_dict:
-                    quickchart_dict["hxl_preview_config"] = json.loads(
-                        quickchart_dict["hxl_preview_config"]
-                    )
-                quickchart_dicts.append(quickchart_dict)
-
-    assert len(quickchart_dicts) == 2
-    assert quickchart_dicts[1]["title"] == "Quick Charts"
 
 
 def test_get_approved_tag_list():


### PR DESCRIPTION
## Purpose

Version for this PR: 2026.2.1

This PR removes functionality dependent on the HXL functionality on HDX, which is being retired. Primarily this is the removal of the `quickcharts` command. Although there are a couple of incidental removals of the `hxl_update=False` parameter from a couple of calls.

- #57


## Major file changes
Describe major file changes in brief

## Minor file changes
Removed instances

## Versioning

`hdx-cli-toolkit` uses the CalVer versioning scheme with format YYYY.MM.Micro i.e. 2022.12.1 which is updated manually in `pyproject.toml`. The "Micro" component is simply an integer increased by 1 at each version, starting from 0.
- [x] Version updated in `pyproject.toml` and PR description
- [x] Update README.md and DEMO.md with any new CLI commands
